### PR TITLE
The sassc executable found via search path. Atom link is always to the top-level atom.xml file.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ dev_dependencies:
   sass: any
 transformers:
 - sass:
-    executable: /home/gmosx/Code/sassc
+    executable: sassc
 - flare/metadata_extractor
 - flare/metadata_translator
 - flare/markdown_transformer

--- a/web/_footer.inc.html
+++ b/web/_footer.inc.html
@@ -1,4 +1,4 @@
 <footer>
   <hr>
-  &copy; 2014 George Moschovitis. <a href="atom.xml">Atom</a> feed.
+  &copy; 2014 George Moschovitis. <a href="/atom.xml">Atom</a> feed.
 </footer>


### PR DESCRIPTION
1. The sassc executable is now found on the search path.
2. The link to atom.xml had been relative to the current page. Now it is always the atom.xml for the site, at the content root.
